### PR TITLE
Hide non controlled combat

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2250,6 +2250,10 @@
                 "Name": "Collapse Item Cards in Chat"
             },
             "CombatCards": {
+				"ConfigureHint": "Configure options for combat cards.",
+				"ConfigureName": "Configure Combat Cards Settings",
+				"ConfigureLabel": "Combat Cards Settings",
+				"ChatCardsHeader": "Chat Cards Display",
                 "NormalHint": "Change which combat chat cards should be displayed during normal combat.",
                 "NormalName": "Normal combat",
                 "StarshipHint": "Change which combat chat cards should be displayed during starship combat.",
@@ -2262,7 +2266,43 @@
                     "RoundsTurns": "Rounds and turns"
                 },
                 "VehicleChaseHint": "Change which combat chat cards should be displayed during vehicle chases.",
-                "VehicleChaseName": "Vehicle chases"
+                "VehicleChaseName": "Vehicle chases",
+				"DisplayHeader": "Display Combat Cards",
+				"EnemyDisplayHint": "Change what is the minimum permission required to display combat cards for enemies.",
+				"EnemyDisplayName": "Enemies",
+				"NeutralDisplayHint": "Change what is the minimum permission required to display combat cards for neutral characters.",
+				"NeutralDisplayName": "Neutrals",
+				"FriendlyDisplayHint": "Change what is the minimum permission required to display combat cards for friendly characters.",
+				"FriendlyDisplayName": "Friendlies",
+				"SecretDisplayHint": "Change what is the minimum permission required to display combat cards for secret characters.",
+				"SecretDisplayName": "Secrets",
+				"HiddenDisplayHint": "Change what is the minimum permission required to display combat cards for characters that are hidden.",
+				"HiddenDisplayName": "Hidden",
+				"ObfuscateHeader": "Hide Names on Chat Cards",
+				"EnemyObfuscateHint": "Change what permissions hide the names of enemy combat cards.",
+				"EnemyObfuscateName": "Hide Enemy Names",
+				"NeutralObfuscateHint": "Change what permissions hide the names of neutral combat cards.",
+				"NeutralObfuscateName": "Hide Neutral Names",
+				"FriendlyObfuscateHint": "Change what permissions hide the names of friendly combat cards.",
+				"FriendlyObfuscateName": "Hide Friendly Names",
+				"SecretObfuscateHint": "Change what permissions hide the names of secret combat cards.",
+				"SecretObfuscateName": "Hide Secret Names",
+				"HiddenObfuscateHint": "Change what permissions hide the names of hidden combat cards.",
+				"HiddenObfuscateName": "Hide Hidden Names",
+				"DisplayOwnedHint": "If checked, users will always see full combat cards of tokens they own.",
+				"DisplayOwnedName": "Override for Owned",
+				"DisplayValues": {
+					"GM": "Game Master",
+					"Assistant": "Game Master and Assistant",
+					"Trusted": "Everyone except Normal Players",
+					"Player": "Everyone"
+				},
+				"ObfuscateValues": {
+					"Assistant": "Everyone except Game Master",
+					"Trusted": "Everyone except Game Master and Assistant",
+					"Player": "Only Normal Players",
+					"None": "No One"
+				}
             },
             "CombatTiebreaker": {
                 "Hint": "Automatically add the initiative modifier divided by 100 to the roll, to help with tie breakers.",
@@ -2334,6 +2374,7 @@
                 "Hint": "Enables the Galactic Trade subsystem, allowing the maximum BP on a ship to be 5% higher than normal, and adds BPs to the ship inventory as credits.",
                 "Name": "Enable Galactic Trade"
             },
+			
             "SFRPGTheme": {
                 "Hint": "When enabled, a few minor tweaks to Foundry's colours will be made to match Starfinder's colour scheme.",
                 "Name": "Custom SFRPG theme"

--- a/src/less/chat.less
+++ b/src/less/chat.less
@@ -104,6 +104,61 @@
     }
 }
 
+.chat-message.message.sfrpg-marker-round {
+	border: none;
+    border-radius: 0 0 20px 0;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin: 0;
+    border-right: solid 1px;
+	border-bottom: solid 1px;
+	
+	.message-sender {
+		display: none;
+	}
+	
+	.card-header {
+		border: none;
+		margin-top: -1.2em;
+	}
+}
+
+.chat-message.message.sfrpg-marker-phase {
+	border: none;
+    border-radius: 0 0 20px 0;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin-left: 0;
+    margin-right: 20px;
+    margin-top: 0;
+	border-right: solid 1px;
+	border-bottom: solid 1px;
+	
+	.message-sender {
+		display: none;
+	}
+	
+	.card-header {
+		border: none;
+		margin-top: -1.2em;
+	}
+}
+
+.chat-message.message.sfrpg-marker-turn {
+	.message-sender {
+		display: none;
+	}
+	
+	.card-header {
+		border: none;
+		margin-top: -1.2em;
+	}
+	
+	.whisper-to {
+		display: none;
+	}
+}
+
 .message-content {
     h2 {
         font-weight: bold;

--- a/src/module/classes/combat-card-menu.js
+++ b/src/module/classes/combat-card-menu.js
@@ -1,0 +1,92 @@
+export default class CombatCardMenu extends FormApplication {
+    constructor(...args) {
+        super(...args);
+    }
+	
+	const tokenTypes = {"Enemy", "Neutral", "Friendly", "Secret", "Hidden"};
+	const displayChoices = {
+		"GM": "SFRPG.Settings.CombatCards.DisplayValues.GM",
+		"Assistant": "SFRPG.Settings.CombatCards.DisplayValues.Assistant",
+		"Trusted": "SFRPG.Settings.CombatCards.DisplayValues.Trusted",
+		"Player": "SFRPG.Settings.CombatCards.DisplayValues.Player"
+	};
+	const obfuscateChoices = {
+		"Assistant": "SFRPG.Settings.CombatCards.ObfuscateValues.Assistant",
+		"Trusted": "SFRPG.Settings.CombatCards.ObfuscateValues.Trusted",
+		"Player": "SFRPG.Settings.CombatCards.ObfuscateValues.Player",
+		"None": "SFRPG.Settings.CombatCards.ObfuscateValues.None"
+	};
+	const chatcardChoices = {
+		"enabled": "SFRPG.Settings.CombatCards.Values.Enabled",
+		"roundsPhases": "SFRPG.Settings.CombatCards.Values.RoundsPhases",
+		"roundsTurns": "SFRPG.Settings.CombatCards.Values.RoundsTurns",
+		"roundsOnly": "SFRPG.Settings.CombatCards.Values.OnlyRounds",
+		"disabled": "SFRPG.Settings.CombatCards.Values.Disabled"
+	};
+
+    getData() {
+        let data = super.getData();
+		data.chatcardsAvailable = chatcardChoices;
+		data.displayAvailable = displayChoices;
+		data.obfuscateAvailable = obfuscateChoices;
+		
+		
+		data.difficultyDisplay = game.settings.get("sfrpg", "difficultyDisplay");
+		
+		data.chatcardsNormal = game.settings.get("sfrpg", "normalChatCards");
+		data.chatcardsStarship = game.settings.get("sfrpg", "normalChatCards");
+		data.chatcardsVehicle = game.settings.get("sfrpg", "vehicleChaseChatCards");
+		
+		data.displayEnemy = game.settings.get("sfrpg", "EnemyDisplayCombatCards");
+		data.displayNeutral = game.settings.get("sfrpg", "NeutralDisplayCombatCards");
+		data.displayFriendly = game.settings.get("sfrpg", "FriendlyDisplayCombatCards");
+		data.displaySecret = game.settings.get("sfrpg", "SecretDisplayCombatCards");
+		data.displayHidden = game.settings.get("sfrpg", "HiddenDisplayCombatCards");
+		
+		data.obfuscateEnemy = game.settings.get("sfrpg", "EnemyObfuscateCombatCards");
+		data.obfuscateNeutral = game.settings.get("sfrpg", "NeutralObfuscateCombatCards");
+		data.obfuscateFriendly = game.settings.get("sfrpg", "FriendlyObfuscateCombatCards");
+		data.obfuscateSecret = game.settings.get("sfrpg", "SecretObfuscateCombatCards");
+		data.obfuscateHidden = game.settings.get("sfrpg", "HiddenObfuscateCombatCards");
+		
+		data.displayOwned = game.settings.get("sfrpg", "displayOwnedCombatCards");
+
+        return data;
+    }
+
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ['form'],
+            popOut: true,
+            template: `systems/sfrpg/templates/apps/combatcards.hbs`,
+            id: 'combat-cards',
+            title: 'SFRPG.Settings.CombatCards.ConfigureLabel',
+            width: 700
+        });
+    }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+    }
+
+    async _updateObject(event, formData) {
+        await Promise.all([
+			game.settings.set("sfrpg", "difficultyDisplay", formData["difficulty-display"]),
+            game.settings.set("sfrpg", "normalChatCards", formData["chatcards-normal"]),
+            game.settings.set("sfrpg", "starshipChatCards", formData["chatcards-starship"]),
+            game.settings.set("sfrpg", "vehicleChaseChatCards", formData["chatcards-vehicle"]),
+			game.settings.set("sfrpg", "EnemyDisplayCombatCards", formData["display-enemy"]),
+			game.settings.set("sfrpg", "NeutralDisplayCombatCards", formData["display-neutral"]),
+			game.settings.set("sfrpg", "FriendlyDisplayCombatCards", formData["display-friendly"]),
+			game.settings.set("sfrpg", "SecretDisplayCombatCards", formData["display-secret"]),
+			game.settings.set("sfrpg", "HiddenDisplayCombatCards", formData["display-hidden"]),
+			game.settings.set("sfrpg", "EnemyObfuscateCombatCards", formData["obfuscate-enemy"]),
+			game.settings.set("sfrpg", "NeutralObfuscateCombatCards", formData["obfuscate-neutral"]),
+			game.settings.set("sfrpg", "FriendlyObfuscateCombatCards", formData["obfuscate-friendly"]),
+			game.settings.set("sfrpg", "SecretObfuscateCombatCards", formData["obfuscate-secret"]),
+			game.settings.set("sfrpg", "HiddenObfuscateCombatCards", formData["obfuscate-hidden"]),        
+			game.settings.set("sfrpg", "DisplayOwned", formData["obfuscate-hidden"]),
+			game.settings.set("sfrpg", "displayOwnedCombatCards", formData["display-owned"])
+		]);
+    }
+}

--- a/src/module/classes/combat-card-menu.js
+++ b/src/module/classes/combat-card-menu.js
@@ -3,29 +3,32 @@ export default class CombatCardMenu extends FormApplication {
         super(...args);
     }
 	
-	const tokenTypes = {"Enemy", "Neutral", "Friendly", "Secret", "Hidden"};
-	const displayChoices = {
-		"GM": "SFRPG.Settings.CombatCards.DisplayValues.GM",
-		"Assistant": "SFRPG.Settings.CombatCards.DisplayValues.Assistant",
-		"Trusted": "SFRPG.Settings.CombatCards.DisplayValues.Trusted",
-		"Player": "SFRPG.Settings.CombatCards.DisplayValues.Player"
-	};
-	const obfuscateChoices = {
-		"Assistant": "SFRPG.Settings.CombatCards.ObfuscateValues.Assistant",
-		"Trusted": "SFRPG.Settings.CombatCards.ObfuscateValues.Trusted",
-		"Player": "SFRPG.Settings.CombatCards.ObfuscateValues.Player",
-		"None": "SFRPG.Settings.CombatCards.ObfuscateValues.None"
-	};
-	const chatcardChoices = {
-		"enabled": "SFRPG.Settings.CombatCards.Values.Enabled",
-		"roundsPhases": "SFRPG.Settings.CombatCards.Values.RoundsPhases",
-		"roundsTurns": "SFRPG.Settings.CombatCards.Values.RoundsTurns",
-		"roundsOnly": "SFRPG.Settings.CombatCards.Values.OnlyRounds",
-		"disabled": "SFRPG.Settings.CombatCards.Values.Disabled"
-	};
+	
 
     getData() {
         let data = super.getData();
+		
+		const tokenTypes = ["Enemy", "Neutral", "Friendly", "Secret", "Hidden"];
+		const displayChoices = {
+			"GM": "SFRPG.Settings.CombatCards.DisplayValues.GM",
+			"Assistant": "SFRPG.Settings.CombatCards.DisplayValues.Assistant",
+			"Trusted": "SFRPG.Settings.CombatCards.DisplayValues.Trusted",
+			"Player": "SFRPG.Settings.CombatCards.DisplayValues.Player"
+		};
+		const obfuscateChoices = {
+			"Assistant": "SFRPG.Settings.CombatCards.ObfuscateValues.Assistant",
+			"Trusted": "SFRPG.Settings.CombatCards.ObfuscateValues.Trusted",
+			"Player": "SFRPG.Settings.CombatCards.ObfuscateValues.Player",
+			"None": "SFRPG.Settings.CombatCards.ObfuscateValues.None"
+		};
+		const chatcardChoices = {
+			"enabled": "SFRPG.Settings.CombatCards.Values.Enabled",
+			"roundsPhases": "SFRPG.Settings.CombatCards.Values.RoundsPhases",
+			"roundsTurns": "SFRPG.Settings.CombatCards.Values.RoundsTurns",
+			"roundsOnly": "SFRPG.Settings.CombatCards.Values.OnlyRounds",
+			"disabled": "SFRPG.Settings.CombatCards.Values.Disabled"
+		};
+		
 		data.chatcardsAvailable = chatcardChoices;
 		data.displayAvailable = displayChoices;
 		data.obfuscateAvailable = obfuscateChoices;
@@ -85,7 +88,6 @@ export default class CombatCardMenu extends FormApplication {
 			game.settings.set("sfrpg", "FriendlyObfuscateCombatCards", formData["obfuscate-friendly"]),
 			game.settings.set("sfrpg", "SecretObfuscateCombatCards", formData["obfuscate-secret"]),
 			game.settings.set("sfrpg", "HiddenObfuscateCombatCards", formData["obfuscate-hidden"]),        
-			game.settings.set("sfrpg", "DisplayOwned", formData["obfuscate-hidden"]),
 			game.settings.set("sfrpg", "displayOwnedCombatCards", formData["display-owned"])
 		]);
     }

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -438,9 +438,6 @@ export class CombatSFRPG extends Combat {
 				round: this.round,
 				phase: localizedPhaseName,
 				combatType: localizedCombatName
-            },
-            footer: {
-                content: game.i18n.format(CombatSFRPG.chatCardsText.footer, {combatType: localizedCombatName, combatPhase: localizedPhaseName})
             }
         };
 
@@ -499,6 +496,7 @@ export class CombatSFRPG extends Combat {
         const localizedCombatName = this.getCombatName();
         const localizedPhaseName = game.i18n.format(eventData.newPhase.name);
 		
+		const newCombatant = eventData.newCombatant;
 		//-2 Secret, -1 Enemy, 0 Neutral, 1 Friendly
 		const tokenDisposition = newCombatant.token.disposition;
 		//True/False
@@ -506,7 +504,7 @@ export class CombatSFRPG extends Combat {
 		//Array {id: permission} - Permission: 3 = Owner
 		const tokenOwnership = newCombatant.actor.ownership;
 		
-		const filterPermission = "Enemy";
+		var filterPermission = "Enemy";
 		switch (tokenDisposition) {
 			case -2:
 				filterPermission = "Secret";
@@ -532,7 +530,7 @@ export class CombatSFRPG extends Combat {
 		var sendObfuscateCard = new Array();
 		var allSend = true;
 		
-		for (const user in game.users) {
+		for (const user of game.users.contents) {
 			var ownershipValue = tokenOwnership[user._id] || tokenOwnership["default"];
 			switch (user.role) {
 				case 4:
@@ -600,9 +598,6 @@ export class CombatSFRPG extends Combat {
 				phase: localizedPhaseName,
 				combatType: localizedCombatName,
 				turn: eventData.newCombatant.name
-            },
-            footer: {
-                content: game.i18n.format(CombatSFRPG.chatCardsText.footer, {combatType: localizedCombatName, combatPhase: localizedPhaseName})
             }
         };
 
@@ -613,7 +608,7 @@ export class CombatSFRPG extends Combat {
 		const obfuscateHtml = await renderTemplate(obfuscateTemplate, templateData);
 
         // Create the chat message
-		const chatWhisper = allSend ? sendFullCard : []:
+		const chatWhisper = allSend ? [] : sendFullCard;
 		
         const chatData = {
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,

--- a/src/module/system/settings.js
+++ b/src/module/system/settings.js
@@ -292,7 +292,7 @@ export const registerSystemSettings = function() {
         });
     }
 	
-	const tokenTypes = {"Enemy", "Neutral", "Friendly", "Secret", "Hidden"};
+	const tokenTypes = ["Enemy", "Neutral", "Friendly", "Secret", "Hidden"];
 	const displayChoices = {
 		"GM": "SFRPG.Settings.CombatCards.DisplayValues.GM",
 		"Assistant": "SFRPG.Settings.CombatCards.DisplayValues.Assistant",

--- a/src/module/system/settings.js
+++ b/src/module/system/settings.js
@@ -1,4 +1,5 @@
 import FloatingNumberMenu from "../classes/floating-number-menu.js";
+import CombatCardMenu from "../classes/combat-card-menu.js";
 import { SFRPG } from "../config.js";
 import { ItemSFRPG } from "../item/item.js";
 
@@ -108,34 +109,9 @@ export const registerSystemSettings = function() {
         }
     });
 
-    game.settings.register("sfrpg", "difficultyDisplay", {
-        name: "SFRPG.Settings.DifficultyDisplay.Name",
-        hint: "SFRPG.Settings.DifficultyDisplay.Hint",
-        scope: "world",
-        config: true,
-        default: true,
-        type: Boolean,
-        onChange: () => ui.combat.render(false)
-    });
+    
 
-    for (const combatType of SFRPG.combatTypes) {
-        const capitalizedCombatType = combatType[0].toUpperCase() + combatType.slice(1);
-        game.settings.register("sfrpg", `${combatType}ChatCards`, {
-            name: `SFRPG.Settings.CombatCards.${capitalizedCombatType}Name`,
-            hint: `SFRPG.Settings.CombatCards.${capitalizedCombatType}Hint`,
-            scope: "world",
-            config: true,
-            default: "enabled",
-            type: String,
-            choices: {
-                "enabled": "SFRPG.Settings.CombatCards.Values.Enabled",
-                "roundsPhases": "SFRPG.Settings.CombatCards.Values.RoundsPhases",
-                "roundsTurns": "SFRPG.Settings.CombatCards.Values.RoundsTurns",
-                "roundsOnly": "SFRPG.Settings.CombatCards.Values.OnlyRounds",
-                "disabled": "SFRPG.Settings.CombatCards.Values.Disabled"
-            }
-        });
-    }
+    
 
     game.settings.register("sfrpg", "starshipActionsSource", {
         name: "SFRPG.Settings.StarshipActionsSource.Name",
@@ -277,4 +253,86 @@ export const registerSystemSettings = function() {
         type: String,
         default: "LIMITED"
     });
+	
+	//Combat Cards Settings
+	game.settings.registerMenu("sfrpg", "combatCards", {
+        name: "SFRPG.Settings.CombatCards.ConfigureName",
+        label: "SFRPG.Settings.CombatCards.ConfigureLabel",
+        hint: "SFRPG.Settings.CombatCards.ConfigureHint",
+        icon: "fas fa-swords",
+        type: CombatCardMenu
+    });
+	
+	game.settings.register("sfrpg", "difficultyDisplay", {
+        name: "SFRPG.Settings.DifficultyDisplay.Name",
+        hint: "SFRPG.Settings.DifficultyDisplay.Hint",
+        scope: "world",
+        config: true,
+        default: true,
+        type: Boolean,
+        onChange: () => ui.combat.render(false)
+    });
+	
+	for (const combatType of SFRPG.combatTypes) {
+        const capitalizedCombatType = combatType[0].toUpperCase() + combatType.slice(1);
+        game.settings.register("sfrpg", `${combatType}ChatCards`, {
+            name: `SFRPG.Settings.CombatCards.${capitalizedCombatType}Name`,
+            hint: `SFRPG.Settings.CombatCards.${capitalizedCombatType}Hint`,
+            scope: "world",
+            config: true,
+            default: "enabled",
+            type: String,
+            choices: {
+                "enabled": "SFRPG.Settings.CombatCards.Values.Enabled",
+                "roundsPhases": "SFRPG.Settings.CombatCards.Values.RoundsPhases",
+                "roundsTurns": "SFRPG.Settings.CombatCards.Values.RoundsTurns",
+                "roundsOnly": "SFRPG.Settings.CombatCards.Values.OnlyRounds",
+                "disabled": "SFRPG.Settings.CombatCards.Values.Disabled"
+            }
+        });
+    }
+	
+	const tokenTypes = {"Enemy", "Neutral", "Friendly", "Secret", "Hidden"};
+	const displayChoices = {
+		"GM": "SFRPG.Settings.CombatCards.DisplayValues.GM",
+		"Assistant": "SFRPG.Settings.CombatCards.DisplayValues.Assistant",
+		"Trusted": "SFRPG.Settings.CombatCards.DisplayValues.Trusted",
+		"Player": "SFRPG.Settings.CombatCards.DisplayValues.Player"
+	};
+	const obfuscateChoices = {
+		"Assistant": "SFRPG.Settings.CombatCards.ObfuscateValues.Assistant",
+		"Trusted": "SFRPG.Settings.CombatCards.ObfuscateValues.Trusted",
+		"Player": "SFRPG.Settings.CombatCards.ObfuscateValues.Player",
+		"None": "SFRPG.Settings.CombatCards.ObfuscateValues.None"
+	};
+	for (const tokenType of tokenTypes) {
+		game.settings.register("sfrpg", `${tokenType}DisplayCombatCards`, {
+			name: `SFRPG.Settings.CombatCards.DisplayCombatCards.${tokenType}Name`,
+            hint: `SFRPG.Settings.CombatCards.DisplayCombatCards.${tokenType}Hint`,
+            scope: "world",
+            config: true,
+            default: "enabled",
+            type: String,
+            choices: displayChoices
+        });
+		game.settings.register("sfrpg", `${tokenType}ObfuscateCombatCards`, {
+			name: `SFRPG.Settings.CombatCards.ObfuscateCombatCards.${tokenType}Name`,
+            hint: `SFRPG.Settings.CombatCards.ObfuscateCombatCards.${tokenType}Hint`,
+            scope: "world",
+            config: true,
+            default: "enabled",
+            type: String,
+            choices: obfuscateChoices
+        });
+	}
+	
+	game.settings.register("sfrpg", "displayOwnedCombatCards", {
+        name: "SFRPG.Settings.CombatCards.DisplayOwnedName",
+        hint: "SFRPG.Settings.CombatCards.DisplayOwnedHint",
+        scope: "world",
+        config: true,
+        default: true,
+        type: Boolean
+    });
+	
 };

--- a/src/templates/apps/combatcards.hbs
+++ b/src/templates/apps/combatcards.hbs
@@ -1,0 +1,119 @@
+<form>
+	<div class="form-group">
+        <label for="difficulty-display">{{localize "SFRPG.Settings.DifficultyDisplay.Name"}}</label>
+        <input type="checkbox" name="difficulty-display" id="difficulty-display" {{checked difficultyDisplay}}>
+        <p class="notes">{{localize "SFRPG.Settings.DifficultyDisplay.Hint"}}</p>
+    </div>
+
+	<div class="form-separator">
+		<h2>{{localize "SFRPG.Settings.CombatCards.ChatCardsHeader"}}</h2>
+	</div>
+	<div class="form-group">
+        <label for="chatcards-normal">{{localize "SFRPG.Settings.CombatCards.NormalName"}}</label>
+        <select name="chatcards-normal" id="chatcards-normal">
+            {{selectOptions chatcardsAvailable localize=true selected=chatcardsNormal }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.NormalHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="chatcards-starship">{{localize "SFRPG.Settings.CombatCards.StarshipName"}}</label>
+        <select name="chatcards-starship" id="chatcards-starship">
+            {{selectOptions chatcardsAvailable localize=true selected=chatcardsStarship }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.StarshipHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="chatcards-vehicle">{{localize "SFRPG.Settings.CombatCards.VehicleChaseName"}}</label>
+        <select name="chatcards-vehicle" id="chatcards-vehicle">
+            {{selectOptions chatcardsAvailable localize=true selected=chatcardsVehicle }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.VehicleChaseHint"}}</p>
+    </div>
+	<div class="form-separator">
+		<h2>{{localize "SFRPG.Settings.CombatCards.DisplayHeader"}}</h2>
+	</div>
+	<div class="form-group">
+        <label for="display-enemy">{{localize "SFRPG.Settings.CombatCards.EnemyDisplayName"}}</label>
+        <select name="display-enemy" id="display-enemy">
+            {{selectOptions displayAvailable localize=true selected=displayEnemy }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.EnemyDisplayHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="display-neutral">{{localize "SFRPG.Settings.CombatCards.NeutralDisplayName"}}</label>
+        <select name="display-neutral" id="display-neutral">
+            {{selectOptions displayAvailable localize=true selected=displayNeutral }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.NeutralDisplayHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="display-friendly">{{localize "SFRPG.Settings.CombatCards.FriendlyDisplayName"}}</label>
+        <select name="display-friendly" id="display-friendly">
+            {{selectOptions displayAvailable localize=true selected=displayFriendly }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.FriendlyDisplayHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="display-secret">{{localize "SFRPG.Settings.CombatCards.SecretDisplayName"}}</label>
+        <select name="display-secret" id="display-secret">
+            {{selectOptions displayAvailable localize=true selected=displaySecret }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.SecretDisplayHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="display-hidden">{{localize "SFRPG.Settings.CombatCards.HiddenDisplayName"}}</label>
+        <select name="display-hidden" id="display-hidden">
+            {{selectOptions displayAvailable localize=true selected=displayHidden }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.HiddenDisplayHint"}}</p>
+    </div>
+	<div class="form-separator">
+		<h2>{{localize "SFRPG.Settings.CombatCards.ObfuscateHeader"}}</h2>
+	</div>
+	<div class="form-group">
+        <label for="obfuscate-enemy">{{localize "SFRPG.Settings.CombatCards.EnemyObfuscateName"}}</label>
+        <select name="obfuscate-enemy" id="obfuscate-enemy">
+            {{selectOptions obfuscateAvailable localize=true selected=obfuscateEnemy }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.EnemyObfuscateHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="obfuscate-neutral">{{localize "SFRPG.Settings.CombatCards.NeutralObfuscateName"}}</label>
+        <select name="obfuscate-neutral" id="obfuscate-neutral">
+            {{selectOptions obfuscateAvailable localize=true selected=obfuscateNeutral }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.NeutralObfuscateHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="obfuscate-friendly">{{localize "SFRPG.Settings.CombatCards.FriendlyObfuscateName"}}</label>
+        <select name="obfuscate-friendly" id="obfuscate-friendly">
+            {{selectOptions obfuscateAvailable localize=true selected=obfuscateFriendly }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.FriendlyObfuscateHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="obfuscate-secret">{{localize "SFRPG.Settings.CombatCards.SecretObfuscateName"}}</label>
+        <select name="obfuscate-secret" id="obfuscate-secret">
+            {{selectOptions obfuscateAvailable localize=true selected=obfuscateSecret }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.SecretObfuscateHint"}}</p>
+    </div>
+	<div class="form-group">
+        <label for="obfuscate-hidden">{{localize "SFRPG.Settings.CombatCards.HiddenObfuscateName"}}</label>
+        <select name="obfuscate-hidden" id="obfuscate-hidden">
+            {{selectOptions obfuscateAvailable localize=true selected=obfuscateHidden }}
+        </select>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.HiddenObfuscateHint"}}</p>
+    </div>
+	
+    <div class="form-group">
+        <label for="display-owned">{{localize "SFRPG.Settings.CombatCards.DisplayOwnedName"}}</label>
+        <input type="checkbox" name="display-owned" id="display-owned" {{checked displayOwned}}>
+        <p class="notes">{{localize "SFRPG.Settings.CombatCards.DisplayOwnedHint"}}</p>
+    </div>
+    <footer class="sheet-footer flexrow">
+    <button type="submit" name="submit">
+        <i class="fa fa-check"></i> OK
+    </button>
+  </footer>
+</form>

--- a/src/templates/chat/combat-card.hbs
+++ b/src/templates/chat/combat-card.hbs
@@ -18,9 +18,9 @@
         {{/if}}
     </div>
 
-    <footer class="card-footer">
-		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
-		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}} {{body.phase}}</div>{{/if}}
-        {{#if footer.content}}<div style="flex:3" class="round-footer-item extraInfo">{{footer.content}}</div>
+    <footer class="card-footer" style="display:flex">
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} </div>{{/if}}
+		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{body.phase}} {{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}}</div>{{/if}}
+        {{#if footer.content}}<div style="flex:3" class="round-footer-item extraInfo">{{footer.content}}</div>{{/if}}
     </footer>
 </div>

--- a/src/templates/chat/combat-card.hbs
+++ b/src/templates/chat/combat-card.hbs
@@ -19,6 +19,8 @@
     </div>
 
     <footer class="card-footer">
-        {{footer.content}}
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
+		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}} {{body.phase}}</div>{{/if}}
+        {{#if footer.content}}<div style="flex:3" class="round-footer-item extraInfo">{{footer.content}}</div>
     </footer>
 </div>

--- a/src/templates/chat/obfuscate-combat-card.hbs
+++ b/src/templates/chat/obfuscate-combat-card.hbs
@@ -1,0 +1,15 @@
+<div class="sfrpg chat-card combat-card">
+    <header class="card-header flexrow">
+        <img src="icons/svg/mystery-man.svg" title="???" width="36" height="36"/>
+        <h3 class="item-name noborder">???</h3>
+    </header>
+
+    <div class="card-content">
+        <h3 class="noborder">????'s Turn</h3>
+    </div>
+
+    <footer class="card-footer">
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
+		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}} {{body.phase}}</div>{{/if}}
+    </footer>
+</div>

--- a/src/templates/chat/obfuscate-combat-card.hbs
+++ b/src/templates/chat/obfuscate-combat-card.hbs
@@ -8,8 +8,8 @@
         <h3 class="noborder">????'s Turn</h3>
     </div>
 
-    <footer class="card-footer">
-		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
+    <footer class="card-footer" style="display:flex">
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}}</div>{{/if}}
 		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}} {{body.phase}}</div>{{/if}}
     </footer>
 </div>

--- a/src/templates/chat/phase-marker.hbs
+++ b/src/templates/chat/phase-marker.hbs
@@ -1,0 +1,14 @@
+<div class="sfrpg chat-card phase-marker" {{#if body.phase}}data-phase="{{body.phase}}"{{/if}} {{#if body.backgroundColor}}style="background-color:{{body.backgroundColor}}"{{/if}}>
+    <header class="card-header flexrow">
+        <h3 class="item-name noborder">{{localize "SFRPG.AbilityActivationTypesRound"}} {{body.phase}}</h3>
+    </header>
+
+    <div class="card-content">
+        <h2 {{#if body.headerColor}}style="background-color:{{body.headerColor}}"{{/if}}>{{body.header}}</h2>
+    </div>
+
+    <footer class="card-footer" style="display:flex">
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
+        {{footer.content}}
+    </footer>
+</div>

--- a/src/templates/chat/phase-marker.hbs
+++ b/src/templates/chat/phase-marker.hbs
@@ -1,6 +1,6 @@
 <div class="sfrpg chat-card phase-marker" {{#if body.phase}}data-phase="{{body.phase}}"{{/if}} {{#if body.backgroundColor}}style="background-color:{{body.backgroundColor}}"{{/if}}>
     <header class="card-header flexrow">
-        <h3 class="item-name noborder">{{localize "SFRPG.AbilityActivationTypesRound"}} {{body.phase}}</h3>
+        <h3 class="item-name noborder">{{body.phase}} {{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}}</h3>
     </header>
 
     <div class="card-content">
@@ -8,7 +8,7 @@
     </div>
 
     <footer class="card-footer" style="display:flex">
-		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}}</div>{{/if}}
         {{footer.content}}
     </footer>
 </div>

--- a/src/templates/chat/round-marker.hbs
+++ b/src/templates/chat/round-marker.hbs
@@ -1,0 +1,16 @@
+<div class="sfrpg chat-card round-marker" {{#if body.round}}data-round="{{body.round}}"{{/if}} {{#if body.backgroundColor}}style="background-color:{{body.backgroundColor}}"{{/if}}>
+    <header class="card-header flexrow">
+        <h3 class="item-name noborder">{{localize "SFRPG.AbilityActivationTypesRound"}} {{body.round}}</h3>
+    </header>
+
+    <div class="card-content">
+        <h2 {{#if body.headerColor}}style="background-color:{{body.headerColor}}"{{/if}}>{{body.header}}</h2>
+        
+    </div>
+
+    <footer class="card-footer" style="display:flex">
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
+		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}} {{body.phase}}</div>{{/if}}
+		{{#if footer.content}}<div style="flex:3" class="round-footer-item extraInfo">{{footer.content}}</div>
+    </footer>
+</div>

--- a/src/templates/chat/round-marker.hbs
+++ b/src/templates/chat/round-marker.hbs
@@ -9,8 +9,8 @@
     </div>
 
     <footer class="card-footer" style="display:flex">
-		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}} {{localize "SFRPG.Combat.Normal.Phases.1.Name"}}</div>{{/if}}
-		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}} {{body.phase}}</div>{{/if}}
-		{{#if footer.content}}<div style="flex:3" class="round-footer-item extraInfo">{{footer.content}}</div>
+		{{#if body.combatType}}<div style="flex:1" class="round-footer-item combatType" data-combat-type="{{body.combatType}}">{{body.combatType}}</div>{{/if}}
+		{{#if body.phase}}<div style="flex:1" class="round-footer-item phase" data-phase="{{body.phase}}">{{body.phase}} {{localize "SFRPG.StarshipSheet.Actions.Header.Phase"}}</div>{{/if}}
+		{{#if footer.content}}<div style="flex:3" class="round-footer-item extraInfo">{{footer.content}}</div>{{/if}}
     </footer>
 </div>


### PR DESCRIPTION
This update abstracts out the functionality of providing turn notifications to a system in which it can determine who needs to receive a turn marker, and what they need to receive. This functionality adds both the capability of preventing people from seeing Obfuscated markers as well.